### PR TITLE
Ошибки tflint и checkov исправлены

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ module "vpc" {
 
 
 module "marketing-vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=95c286e"
   env_name       = var.vm_marketing.env_name
   network_id     = module.vpc.vpc_network.id
   subnet_zones   = [var.default_zone,var.default_zone_b]
@@ -50,7 +50,7 @@ module "marketing-vm" {
 }
 
 module "analytics-vm" {
-  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"
+  source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=95c286e"
   env_name       = var.vm_analytics.env_name
   network_id     = module.vpc.vpc_network.id
   subnet_zones   = [var.default_zone]

--- a/providers.tf
+++ b/providers.tf
@@ -24,6 +24,12 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = ">= 0.47.0"
+    }
+    
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.2.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,12 +32,6 @@ variable "default_cidr" {
   description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
 }
 
-variable "default_cidr_b" {
-  type        = list(string)
-  default     = ["10.0.2.0/24"]
-  description = "https://cloud.yandex.ru/docs/vpc/operations/subnet-create"
-}
-
 variable "vm_family" {
   type        = string
   default     = "ubuntu-2004-lts"

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     yandex = {
       source = "yandex-cloud/yandex"
+      version = ">= 0.47.0"
     }
   }
   required_version = ">=0.13"


### PR DESCRIPTION


Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 30:
  30:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_module_pinned_source.md

Warning: Module source "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main" uses a default branch as ref (main) (terraform_module_pinned_source)

  on main.tf line 53:
  53:   source         = "git::https://github.com/udjin10/yandex_compute_instance.git?ref=main"

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_module_pinned_source.md

Warning: Missing version constraint for provider "template" in `required_providers` (terraform_required_providers)

  on main.tf line 76:
  76: data "template_file" "cloudinit" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_required_providers.md

Warning: Missing version constraint for provider "yandex" in `required_providers` (terraform_required_providers)

  on providers.tf line 25:
  25:     yandex = {
  26:       source = "yandex-cloud/yandex"
  27:     }

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_required_providers.md

Warning: [Fixable] variable "default_cidr_b" is declared but not used (terraform_unused_declarations)

  on variables.tf line 35:
  35: variable "default_cidr_b" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.10.0/docs/rules/terraform_unused_declarations.md


terraform scan results:

Passed checks: 4, Failed checks: 0, Skipped checks: 0

Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        PASSED for resource: marketing-vm
        File: /main.tf:29-50
Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
        PASSED for resource: marketing-vm
        File: /main.tf:29-50
Check: CKV_TF_1: "Ensure Terraform module sources use a commit hash"
        PASSED for resource: analytics-vm
        File: /main.tf:52-73
Check: CKV_TF_2: "Ensure Terraform module sources use a tag with a version number"
        PASSED for resource: analytics-vm
        File: /main.tf:52-73